### PR TITLE
feat(COM-2525): added preview url and scoring block

### DIFF
--- a/dist/bundle.yaml
+++ b/dist/bundle.yaml
@@ -3,7 +3,7 @@ info:
   title: The CareerOS API
   description: The CareerOS server API documentation
   contact: {}
-  version: 1.3.1
+  version: 1.3.2
   license:
     name: CareerOS internal usage license
     url: https://github.com/CareerOS/openapi/blob/main/LICENSE_TCOS
@@ -1910,7 +1910,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Resume'
+                  $ref: '#/components/schemas/tailored_resume_response'
         '401':
           description: Unauthorized
           content:
@@ -3414,8 +3414,10 @@ components:
           format: uuid
           example: a4bd6f2b-fb4e-48ec-909d-42b71953f3ed
         name:
-          type: string
-          example: My resume
+          type:
+            - 'null'
+            - string
+          example: ESMT
         preview_image:
           type: string
           format: uri
@@ -3435,6 +3437,9 @@ components:
         user_id:
           type: string
           example: 7d7f5b28-0c7c-4af9-8a15-e421e71ec39b
+        preview_url:
+          type: string
+          example: https://placehold.co/100x500
         title:
           type: string
           example: My resume
@@ -3457,6 +3462,9 @@ components:
         user_id:
           type: string
           example: 7d7f5b28-0c7c-4af9-8a15-e421e71ec39b
+        preview_url:
+          type: string
+          example: https://placehold.co/100x500
         job_id:
           type: string
           example: 39c1f722-0a17-44b7-a121-03165effc81a
@@ -3554,6 +3562,8 @@ components:
     Consistency:
       type: object
       properties:
+        all_bullets_start_with_capital_letter:
+          $ref: '#/components/schemas/Block'
         all_bullets_end_with_period_or_none:
           $ref: '#/components/schemas/Block'
         overusage_of_action_verbs_in_bullets:
@@ -3565,7 +3575,7 @@ components:
           example: 50
         weight:
           type: integer
-          example: 3
+          example: 4
     Score:
       type: object
       properties:

--- a/openapi/components/schemas/resumes/Resume_template.yaml
+++ b/openapi/components/schemas/resumes/Resume_template.yaml
@@ -8,8 +8,10 @@ properties:
     format: uuid
     example: a4bd6f2b-fb4e-48ec-909d-42b71953f3ed
   name:
-    type: string
-    example: My resume
+    type: 
+      - "null"
+      - string
+    example: ESMT
   preview_image:
     type: string
     format: uri

--- a/openapi/components/schemas/resumes/base_resume_response.yaml
+++ b/openapi/components/schemas/resumes/base_resume_response.yaml
@@ -6,6 +6,9 @@ properties:
   user_id: 
     type: string
     example: 7d7f5b28-0c7c-4af9-8a15-e421e71ec39b
+  preview_url:
+    type: string
+    example: https://placehold.co/100x500
   title:
     type: string
     example: My resume

--- a/openapi/components/schemas/resumes/score/Consistency.yaml
+++ b/openapi/components/schemas/resumes/score/Consistency.yaml
@@ -1,5 +1,7 @@
 type: object
 properties:
+  all_bullets_start_with_capital_letter:
+    $ref: ./Block.yaml
   all_bullets_end_with_period_or_none: 
     $ref: ./Block.yaml
   overusage_of_action_verbs_in_bullets: 
@@ -11,4 +13,4 @@ properties:
     example: 50
   weight: 
     type: integer
-    example: 3
+    example: 4

--- a/openapi/components/schemas/resumes/tailored_resume_response.yaml
+++ b/openapi/components/schemas/resumes/tailored_resume_response.yaml
@@ -6,6 +6,9 @@ properties:
   user_id: 
     type: string
     example: 7d7f5b28-0c7c-4af9-8a15-e421e71ec39b
+  preview_url:
+    type: string
+    example: https://placehold.co/100x500
   job_id:
     type: string
     example: 39c1f722-0a17-44b7-a121-03165effc81a

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -4,7 +4,7 @@ info:
   title: The CareerOS API
   description: The CareerOS server API documentation
   contact: {}
-  version: 1.3.1
+  version: 1.3.2
   license:
     name: CareerOS internal usage license
     url: https://github.com/CareerOS/openapi/blob/main/LICENSE_TCOS

--- a/openapi/paths/resumes/tailored.yaml
+++ b/openapi/paths/resumes/tailored.yaml
@@ -52,7 +52,7 @@ get:
           schema:
             type: array
             items:
-              $ref: ../../components/schemas/resumes/Resume.yaml
+              $ref: ../../components/schemas/resumes/tailored_resume_response.yaml
     '401':
       description: Unauthorized
       content:

--- a/package-lock.json
+++ b/package-lock.json
@@ -343,11 +343,11 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -982,9 +982,9 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -2993,9 +2993,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -3318,11 +3318,11 @@
       }
     },
     "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       }
     },
     "call-bind": {
@@ -3798,9 +3798,9 @@
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA=="
     },
     "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -5235,9 +5235,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "ws": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
-      "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "requires": {}
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openapi",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "dependencies": {
     "@redocly/cli": "1.16.0"
   },


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit f7d1224ed6baa33a7186c690f1992a0c453c10fa  | 
|--------|--------|

### Summary:
Added `preview_url` to resume responses and `all_bullets_start_with_capital_letter` to consistency scoring.

**Key points**:
- Updated `openapi/components/schemas/resumes/Resume_template.yaml` to allow `name` to be `null`.
- Added `preview_url` property to `openapi/components/schemas/resumes/base_resume_response.yaml` and `openapi/components/schemas/resumes/tailored_resume_response.yaml`.
- Added `all_bullets_start_with_capital_letter` property to `openapi/components/schemas/resumes/score/Consistency.yaml`.
- Updated `openapi/paths/resumes/tailored.yaml` to reference `tailored_resume_response.yaml` instead of `Resume.yaml`.
- Bumped version in `openapi/openapi.yaml` and `package.json` to `1.3.2`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->