### PR TITLE
fix(COM-1270): changed the wrong method

### DIFF
--- a/dist/bundle.yaml
+++ b/dist/bundle.yaml
@@ -1212,7 +1212,7 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
   /api/v1/companies/favorite/{id}:
-    get:
+    post:
       tags:
         - Favorite Companies
       summary: Toggle favorite company

--- a/openapi/paths/favorite/by_id.yaml
+++ b/openapi/paths/favorite/by_id.yaml
@@ -1,4 +1,4 @@
-get:
+post:
   tags:
     - Favorite Companies
   summary: Toggle favorite company


### PR DESCRIPTION
The Jira ticket is [here](https://thecareeros.atlassian.net/browse/COM-1270).
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit edac37fb95d52fb125602539e675fb8d60f2fab4  | 
|--------|--------|

### Summary:
Changed HTTP method from `get` to `post` in `openapi/paths/favorite/by_id.yaml` to correctly reflect the toggle action for favorite companies.

**Key points**:
- Changed HTTP method from `get` to `post` in `openapi/paths/favorite/by_id.yaml`.
- Ensures the `toggleFavoriteCompany` operation correctly reflects a data modification action.
- Affects the endpoint for toggling favorite companies by ID and current userID.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->