### PR TITLE
fix(COM-1274): fixed the path

### DIFF
--- a/dist/bundle.yaml
+++ b/dist/bundle.yaml
@@ -2212,7 +2212,7 @@ paths:
           $ref: '#/components/responses/UnauthorizedError'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /api/v1/users/users/conversations:
+  /api/v1/users/conversations:
     get:
       tags:
         - Users

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -165,7 +165,7 @@ paths:
     $ref: paths/users/self.yaml
   /api/v1/users/contacts:
     $ref: paths/users/contacts.yaml
-  /api/v1/users/users/conversations:
+  /api/v1/users/conversations:
     $ref: paths/users/conversations.yaml
   /api/v1/users/self/lid:
     $ref: paths/users/self_lid.yaml


### PR DESCRIPTION
The Jira ticket is [here](https://thecareeros.atlassian.net/browse/COM-1274).
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 0509a926afbdc89e35c2a2897ed133559ecbc1cb  | 
|--------|--------|

### Summary:
Fixed incorrect path reference in `openapi/openapi.yaml` from `/api/v1/users/users/conversations` to `/api/v1/users/conversations`.

**Key points**:
- Corrected path reference in `openapi/openapi.yaml`.
- Changed `/api/v1/users/users/conversations` to `/api/v1/users/conversations`.
- Ensures accurate API documentation and routing.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->